### PR TITLE
Add benchmarking columns, build out some more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Scripts for processing MBTA performance data both from LAMP and from monthly his
 ## Instructions to run locally
 
 1. Add your AWS credentials (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY) to your shell environment, OR add them to a .boto config file with awscli command `aws configure`.
+
+## Testing
+1. From the `mbta-performance` directory, set up the poetry with `poetry shell; poetry install`
+2. From the `mbta-performance` directory, run `poetry run pytest`

--- a/mbta-performance/chalicelib/lamp/ingest.py
+++ b/mbta-performance/chalicelib/lamp/ingest.py
@@ -28,7 +28,20 @@ INPUT_COLUMNS = [
     "vehicle_label",
     "move_timestamp",  # departure time from the previous station
     "stop_timestamp",  # arrival time at the current station
+    # BENCHMARKING COLUMNS
+    "travel_time_seconds",
+    "dwell_time_seconds",
+    "headway_trunk_seconds",
+    "headway_branch_seconds",
+    "scheduled_travel_time",
+    "scheduled_headway_trunk",
+    "scheduled_headway_branch",
 ]
+
+COLUMN_RENAME_MAP = {
+    "headway_trunk_seconds": "headway_seconds",
+    "scheduled_headway_trunk": "scheduled_headway",
+}
 
 # columns that should be output to s3 events.csv
 OUTPUT_COLUMNS = [
@@ -77,15 +90,15 @@ def _process_arrival_departure_times(pq_df: pd.DataFrame) -> pd.DataFrame:
     """
     pq_df["dep_time"] = pd.to_datetime(pq_df["move_timestamp"], unit="s", utc=True).dt.tz_convert("US/Eastern")
     pq_df["arr_time"] = pd.to_datetime(pq_df["stop_timestamp"], unit="s", utc=True).dt.tz_convert("US/Eastern")
+    pq_df = pq_df.sort_values(by=["stop_sequence"])
 
     # explode departure and arrival times
     arr_df = pq_df[pq_df["arr_time"].notna()]
     arr_df = arr_df.assign(event_type="ARR").rename(columns={"arr_time": "event_time"})
-    arr_df = arr_df.sort_values(by=["stop_sequence"])
+    arr_df = arr_df[OUTPUT_COLUMNS]
 
     dep_df = pq_df[pq_df["dep_time"].notna()]
-    dep_df = dep_df.assign(event_type="DEP").rename(columns={"dep_time": "event_time"}).drop(columns=["arr_time"])
-    dep_df = dep_df.sort_values(by=["stop_sequence"])
+    dep_df = dep_df.assign(event_type="DEP").rename(columns={"dep_time": "event_time"})
 
     # these departures are from the the previous stop! so set them to the previous stop id
     # find the stop id for the departure whose sequence number precences the recorded one
@@ -95,22 +108,29 @@ def _process_arrival_departure_times(pq_df: pd.DataFrame) -> pd.DataFrame:
         arr_df,
         on=["stop_sequence"],
         by=[
-            "service_date",  # comment for faster performance
+            "service_date",  # comment out for faster performance
             "route_id",
             "trip_id",
             "vehicle_id",
-            "vehicle_label",  # comment for faster performance
+            # just merge by vehicle_id, because human-readable label can be inconsistent
+            # "vehicle_label",
             "direction_id",
         ],
         direction="backward",
         suffixes=("_curr", "_prev"),
         allow_exact_matches=False,  # don't want to match on itself
     )
-    # use CURRENT time, but PREVIOUS stop id
-    dep_df = dep_df.rename(columns={"event_time_curr": "event_time", "stop_id_prev": "stop_id"})[OUTPUT_COLUMNS]
+    dep_df = dep_df.rename(
+        columns={
+            "event_time_curr": "event_time",  # use CURRENT time...
+            "stop_id_prev": "stop_id",  # ...but PREVIOUS stop id...
+            "event_type_curr": "event_type",  # keep DEPARTURE label...
+            "vehicle_label_curr": "vehicle_label",  # using the inital label WLOG
+        }
+    )[OUTPUT_COLUMNS]
 
     # stitch together arrivals and departures
-    return pd.concat([arr_df[OUTPUT_COLUMNS], dep_df[OUTPUT_COLUMNS]])
+    return pd.concat([arr_df, dep_df])
 
 
 def fetch_pq_file_from_remote(service_date: date) -> pd.DataFrame:
@@ -138,6 +158,9 @@ def ingest_pq_file(pq_df: pd.DataFrame) -> pd.DataFrame:
     """Process and tranform columns for the full day's events."""
     pq_df["direction_id"] = pq_df["direction_id"].astype("int16")
     pq_df["service_date"] = pq_df["service_date"].apply(format_dateint)
+    # use trunk headway metrics as default, and add branch metrics when it makes sense.
+    # TODO: verify and recalculate headway metrics if necessary!
+    pq_df = pq_df.rename(columns=COLUMN_RENAME_MAP)
 
     processed_daily_events = _process_arrival_departure_times(pq_df)
     return processed_daily_events.sort_values(by=["event_time"])

--- a/mbta-performance/chalicelib/lamp/ingest.py
+++ b/mbta-performance/chalicelib/lamp/ingest.py
@@ -55,6 +55,13 @@ OUTPUT_COLUMNS = [
     "vehicle_label",
     "event_type",
     "event_time",
+    "travel_time_seconds",
+    "dwell_time_seconds",
+    "headway_seconds",
+    "headway_branch_seconds",
+    "scheduled_travel_time",
+    "scheduled_headway",
+    "scheduled_headway_branch",
 ]
 
 
@@ -112,8 +119,6 @@ def _process_arrival_departure_times(pq_df: pd.DataFrame) -> pd.DataFrame:
             "route_id",
             "trip_id",
             "vehicle_id",
-            # just merge by vehicle_id, because human-readable label can be inconsistent
-            # "vehicle_label",
             "direction_id",
         ],
         direction="backward",
@@ -125,7 +130,15 @@ def _process_arrival_departure_times(pq_df: pd.DataFrame) -> pd.DataFrame:
             "event_time_curr": "event_time",  # use CURRENT time...
             "stop_id_prev": "stop_id",  # ...but PREVIOUS stop id...
             "event_type_curr": "event_type",  # keep DEPARTURE label...
-            "vehicle_label_curr": "vehicle_label",  # using the inital label WLOG
+            "vehicle_label_curr": "vehicle_label",
+            # Keep all current benchmarking data...
+            "travel_time_seconds_curr": "travel_time_seconds",
+            "dwell_time_seconds_curr": "dwell_time_seconds",
+            "headway_seconds_curr": "headway_seconds",
+            "headway_branch_seconds_curr": "headway_branch_seconds",
+            "scheduled_travel_time_curr": "scheduled_travel_time",
+            "scheduled_headway_curr": "scheduled_headway",
+            "scheduled_headway_branch_curr": "scheduled_headway_branch",
         }
     )[OUTPUT_COLUMNS]
 

--- a/mbta-performance/chalicelib/lamp/tests/test_ingest.py
+++ b/mbta-performance/chalicelib/lamp/tests/test_ingest.py
@@ -20,7 +20,14 @@ class TestIngest(unittest.TestCase):
         pass
 
     def test__process_arrival_departure_times(self):
-        pass
+        pq_df_before = pd.read_parquet(
+            io.BytesIO(self.data),
+            columns=ingest.INPUT_COLUMNS,
+            engine="pyarrow",
+            dtype_backend="numpy_nullable",
+        )
+
+        ingest._process_arrival_departure_times(pq_df)
 
     def test_fetch_pq_file_from_remote(self):
         mock_response = mock.Mock(status_code=200, content=self.data)

--- a/mbta-performance/chalicelib/lamp/tests/test_ingest.py
+++ b/mbta-performance/chalicelib/lamp/tests/test_ingest.py
@@ -27,7 +27,7 @@ class TestIngest(unittest.TestCase):
             columns=ingest.INPUT_COLUMNS,
             engine="pyarrow",
             dtype_backend="numpy_nullable",
-        )
+        ).rename(columns=ingest.COLUMN_RENAME_MAP)
 
         pq_df_after = ingest._process_arrival_departure_times(pq_df_before)
         arrivals = pq_df_after[pq_df_after.event_type == "ARR"]


### PR DESCRIPTION
Killing a couple of birds with 1 stone here
1. Adding the columns necessary for initial benchmarking. This just takes LAMP's values wholesale, but in the past we've completely reworked them as well. Will make those changes in a later PR as needed. 
2. Adding columns for (opposite of what I said on Slack) branch headways. For backwards-compatibility, the `headways` column will refer to trunk headways. `scheduled_headway_branch` and `headway_branch_seconds` will be null, usually, except when they're not. 
3. Added testing for departure/arrival collation, and tweaked the merge calculations for them accordingly.