### PR TITLE
Remove events with null stop ids

### DIFF
--- a/mbta-performance/chalicelib/lamp/tests/test_ingest.py
+++ b/mbta-performance/chalicelib/lamp/tests/test_ingest.py
@@ -97,9 +97,11 @@ class TestIngest(unittest.TestCase):
             pq_df_after = ingest.ingest_pq_file(pq_df_before, date(2024, 2, 7))
         nonrev = pq_df_after[pq_df_after["trip_id"].str.startswith("NONREV-")]
         added = pq_df_after[pq_df_after["trip_id"].str.startswith("ADDED-")]
+        null_id_events = pq_df_after[pq_df_after["stop_id"].isna()]
         self.assertTrue(nonrev.empty)
         self.assertTrue(added.empty)
-        self.assertEqual(pq_df_after.shape, (14801, 18))
+        self.assertTrue(null_id_events.empty)
+        self.assertEqual(pq_df_after.shape, (12937, 17))
         self.assertEqual(set(pq_df_after["service_date"].unique()), {"2024-02-07"})
 
     def test_upload_to_s3(self):


### PR DESCRIPTION
Quick fix for https://github.com/transitmatters/mbta-performance/issues/16, which is 1 of 2(+?) data qual issues we're running into. This PR drops all events with null stop id's because it messes with our schedule merging algorithms. 
2 reasons this is ok:

1. These phantom events aren't even read from on s3 atm because the events data is partitioned, in part, by stop id
2. Many of these events are a phantom departure that occurs before the first stop of a route, so we actively don't care about tracking it.

That being said: some of these null-stop events can also be AVL blips, etc, which we might want to look into more at a later date. 

Uploaded some data from my laptop to s3, beta dashboard is looking a bit healthier now! (: 
https://dashboard-beta.labs.transitmatters.org/green/trips/single/?date=2024-05-08&to=70257&from=70510
https://dashboard-beta.labs.transitmatters.org/blue/trips/single/?date=2024-05-08&to=70039&from=70057