### PR TITLE
Add stop id remap function

### DIFF
--- a/mbta-performance/chalicelib/lamp/constants.py
+++ b/mbta-performance/chalicelib/lamp/constants.py
@@ -45,12 +45,14 @@ S3_COLUMNS = [
 # Live data will sometimes report an aliased version of stop_id different
 # from that which GTFS reports in its schedule. These are the known id's.
 STOP_ID_NUMERIC_MAP = {
+    "Alewife-01": "70061",
+    "Alewife-02": "70061",
     "Forest Hills-01": "70001",
     "Forest Hills-02": "70001",
     "Braintree-01": "70105",
     "Braintree-02": "70105",
     "Oak Grove-01": "70036",
     "Oak Grove-02": "70036",
-    "Union Square-01": "70504",
+    "Union Square-01": "70503",
     "Union Square-02": "70504",
 }

--- a/mbta-performance/chalicelib/lamp/constants.py
+++ b/mbta-performance/chalicelib/lamp/constants.py
@@ -40,3 +40,17 @@ S3_COLUMNS = [
     "scheduled_headway",
     "scheduled_headway_branch",
 ]
+
+
+# Live data will sometimes report an aliased version of stop_id different
+# from that which GTFS reports in its schedule. These are the known id's.
+STOP_ID_NUMERIC_MAP = {
+    "Forest Hills-01": "70001",
+    "Forest Hills-02": "70001",
+    "Braintree-01": "70105",
+    "Braintree-02": "70105",
+    "Oak Grove-01": "70036",
+    "Oak Grove-02": "70036",
+    "Union Square-01": "70504",
+    "Union Square-02": "70504",
+}

--- a/mbta-performance/chalicelib/lamp/ingest.py
+++ b/mbta-performance/chalicelib/lamp/ingest.py
@@ -5,7 +5,7 @@ import pandas as pd
 import requests
 from typing import Iterable, Tuple
 
-from .constants import LAMP_COLUMNS, S3_COLUMNS
+from .constants import LAMP_COLUMNS, S3_COLUMNS, STOP_ID_NUMERIC_MAP
 from ..date import format_dateint, get_current_service_date
 from mbta_gtfs_sqlite import MbtaGtfsArchive
 from mbta_gtfs_sqlite.models import StopTime, Trip
@@ -207,6 +207,9 @@ def ingest_pq_file(pq_df: pd.DataFrame, service_date: date) -> pd.DataFrame:
     # use trunk headway metrics as default, and add branch metrics when it makes sense.
     # TODO: verify and recalculate headway metrics if necessary!
     pq_df = pq_df.rename(columns=COLUMN_RENAME_MAP)
+    # Live data will sometimes report an aliased version of stop_id different
+    # from that which GTFS reports in its schedule. Replace for better schedule matching.
+    pq_df["stop_id"] = pq_df["stop_id"].replace(STOP_ID_NUMERIC_MAP)
     # drop non-revenue producing events
     pq_df = pq_df[~pq_df["trip_id"].str.startswith(TRIP_IDS_TO_DROP)]
 

--- a/mbta-performance/chalicelib/lamp/ingest.py
+++ b/mbta-performance/chalicelib/lamp/ingest.py
@@ -30,7 +30,7 @@ COLUMN_RENAME_MAP = {
 # if a trip_id begins with NONREV-, it is not revenue producing and thus not something we want to benchmark
 # if an event has a trip_id begins with ADDED-, then a downstream process was unable to determine the scheduled trip
 # that the vehicle is currently on (this can be due to AVL glitches, trip diversions, test train trips, etc.)
-TRIP_IDS_TO_DROP = ("NONREV-", "ADDED-")
+TRIP_IDS_TO_DROP = ("NONREV-",)  # "ADDED-")
 
 # information to fetch from GTFS
 TEMP_GTFS_LOCAL_PREFIX = ".temp/gtfs-feeds/"

--- a/mbta-performance/chalicelib/lamp/tests/test_ingest.py
+++ b/mbta-performance/chalicelib/lamp/tests/test_ingest.py
@@ -99,7 +99,7 @@ class TestIngest(unittest.TestCase):
         added = pq_df_after[pq_df_after["trip_id"].str.startswith("ADDED-")]
         null_id_events = pq_df_after[pq_df_after["stop_id"].isna()]
         self.assertTrue(nonrev.empty)
-        self.assertEqual(added.empty, (3763, 17))
+        self.assertEqual(added.shape, (3763, 17))
         self.assertTrue(null_id_events.empty)
         self.assertEqual(pq_df_after.shape, (16700, 17))
         self.assertEqual(set(pq_df_after["service_date"].unique()), {"2024-02-07"})

--- a/mbta-performance/chalicelib/lamp/tests/test_ingest.py
+++ b/mbta-performance/chalicelib/lamp/tests/test_ingest.py
@@ -99,9 +99,9 @@ class TestIngest(unittest.TestCase):
         added = pq_df_after[pq_df_after["trip_id"].str.startswith("ADDED-")]
         null_id_events = pq_df_after[pq_df_after["stop_id"].isna()]
         self.assertTrue(nonrev.empty)
-        self.assertTrue(added.empty)
+        self.assertEqual(added.empty, (3763, 17))
         self.assertTrue(null_id_events.empty)
-        self.assertEqual(pq_df_after.shape, (12937, 17))
+        self.assertEqual(pq_df_after.shape, (16700, 17))
         self.assertEqual(set(pq_df_after["service_date"].unique()), {"2024-02-07"})
 
     def test_upload_to_s3(self):


### PR DESCRIPTION
A lil map which replaces certain stop ID's with the alias that appears on GTFS so that we can correctly merge route start information. Pushed up some data from the past 2 days to s3. We'd expect this to fix issues along the Orange and Red lines, and Green-D from Union Square. 

Looks like Orange is fixed, but Green and Red are still being odd. Investigating more.

Also, adding back in `ADDED-*` stops because all the trips out of Alewife are being reported as `ADDED-` and we don't want to drop them. 