### PR TITLE
Fixing GTFS runs, and initial code for 30 minute average benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .python-version
 .temp
 **/data
+.envrc

--- a/devops/helpers.sh
+++ b/devops/helpers.sh
@@ -9,6 +9,7 @@ function shrink {
     zip -d -qq cfn/layer-deployment.zip '**/NOTICE*'
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/numpy*/tests/**/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/pandas*/tests/**/*
+    zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/pyarrow*/tests/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/pyarrow*/tests/**/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/sqlalchemy*/testing/**/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/tzdata/zoneinfo/Africa/*
@@ -19,6 +20,7 @@ function shrink {
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/tzdata/zoneinfo/Australia/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/tzdata/zoneinfo/Brazil/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/tzdata/zoneinfo/Chile/*
+    zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/tzdata/zoneinfo/Europe/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/tzdata/zoneinfo/Indian/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/tzdata/zoneinfo/Mexico/*
     zip -d -qq cfn/layer-deployment.zip python/lib/**/site-packages/boto*/examples/*

--- a/mbta-performance/.chalice/config.json
+++ b/mbta-performance/.chalice/config.json
@@ -21,7 +21,7 @@
         "process_daily_lamp": {
           "iam_policy_file": "policy-lamp-ingest.json",
           "lambda_timeout": 900,
-          "lambda_memory_size": 4096,
+          "lambda_memory_size": 10240,
           "max_ebs_size_gb": 10
         }
       }

--- a/mbta-performance/.chalice/config.json
+++ b/mbta-performance/.chalice/config.json
@@ -21,8 +21,7 @@
         "process_daily_lamp": {
           "iam_policy_file": "policy-lamp-ingest.json",
           "lambda_timeout": 900,
-          "lambda_memory_size": 2048,
-          "max_ebs_size_gb": 10
+          "lambda_memory_size": 2048
         }
       }
     }

--- a/mbta-performance/.chalice/config.json
+++ b/mbta-performance/.chalice/config.json
@@ -21,7 +21,8 @@
         "process_daily_lamp": {
           "iam_policy_file": "policy-lamp-ingest.json",
           "lambda_timeout": 900,
-          "lambda_memory_size": 2048
+          "lambda_memory_size": 4096,
+          "max_ebs_size_gb": 10
         }
       }
     }

--- a/mbta-performance/.chalice/config.json
+++ b/mbta-performance/.chalice/config.json
@@ -21,7 +21,7 @@
         "process_daily_lamp": {
           "iam_policy_file": "policy-lamp-ingest.json",
           "lambda_timeout": 900,
-          "lambda_memory_size": 10240,
+          "lambda_memory_size": 2048,
           "max_ebs_size_gb": 10
         }
       }

--- a/mbta-performance/.chalice/policy-lamp-ingest.json
+++ b/mbta-performance/.chalice/policy-lamp-ingest.json
@@ -14,6 +14,11 @@
       "Action": ["s3:GetObject", "s3:PutObject"],
       "Effect": "Allow",
       "Resource": ["arn:aws:s3:::tm-mbta-performance/Events-lamp/daily-data/*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": ["arn:aws:s3:::tm-gtfs", "arn:aws:s3:::tm-gtfs/*"]
     }
   ]
 }

--- a/mbta-performance/.chalice/resources.json
+++ b/mbta-performance/.chalice/resources.json
@@ -29,6 +29,9 @@
               "Ref": "DDTags"
             }
           }
+        },
+        "EphemeralStorage": {
+          "Size": 2048
         }
       }
     }

--- a/mbta-performance/app.py
+++ b/mbta-performance/app.py
@@ -9,7 +9,7 @@ app = Chalice(app_name="mbta-performance")
 app.register_middleware(ConvertToMiddleware(datadog_lambda_wrapper))
 
 
-# Runs every 60 minutes from either 4 AM -> 1:55AM or 5 AM -> 2:55 AM depending on DST
-@app.schedule(Cron("0", "0-6,9-23", "*", "*", "?", "*"))
+# Runs every 30 minutes from either 4 AM -> 1:55AM or 5 AM -> 2:55 AM depending on DST
+@app.schedule(Cron("*/30", "0-6,9-23", "*", "*", "?", "*"))
 def process_daily_lamp(event):
     lamp.ingest_today_lamp_data()

--- a/mbta-performance/chalicelib/date.py
+++ b/mbta-performance/chalicelib/date.py
@@ -4,6 +4,11 @@ from zoneinfo import ZoneInfo
 EASTERN_TIME = ZoneInfo("US/Eastern")
 
 
+def to_dateint(date: date):
+    """turn date into 20220615 e.g."""
+    return int(str(date).replace("-", ""))
+
+
 def service_date(ts: datetime) -> date:
     """
     Return the service date for a given timestamp in Eastern time.

--- a/mbta-performance/chalicelib/gtfs.py
+++ b/mbta-performance/chalicelib/gtfs.py
@@ -13,10 +13,11 @@ MAX_QUERY_DEPTH = 900  # actually 1000
 
 def fetch_stop_times_from_gtfs(trip_ids: Iterable[str], service_date: date) -> pd.DataFrame:
     """Fetch scheduled stop time information from GTFS."""
-    mbta_gtfs = MbtaGtfsArchive(TemporaryDirectory(delete=False).name)
+    mbta_gtfs = MbtaGtfsArchive(TemporaryDirectory().name)
     feed = mbta_gtfs.get_feed_for_date(service_date)
+    feed.use_compact_only()
     feed.download_or_build()
-    session = feed.create_sqlite_session()
+    session = feed.create_sqlite_session(compact=True)
 
     gtfs_stops = []
     for start in range(0, len(trip_ids), MAX_QUERY_DEPTH):

--- a/mbta-performance/chalicelib/gtfs.py
+++ b/mbta-performance/chalicelib/gtfs.py
@@ -1,0 +1,36 @@
+from datetime import date
+from tempfile import TemporaryDirectory
+import pandas as pd
+from typing import Iterable
+
+from mbta_gtfs_sqlite import MbtaGtfsArchive
+from mbta_gtfs_sqlite.models import StopTime, Trip
+from sqlalchemy import or_
+
+# information to fetch from GTFS
+MAX_QUERY_DEPTH = 900  # actually 1000
+
+
+def fetch_stop_times_from_gtfs(trip_ids: Iterable[str], service_date: date) -> pd.DataFrame:
+    """Fetch scheduled stop time information from GTFS."""
+    mbta_gtfs = MbtaGtfsArchive(TemporaryDirectory(delete=False).name)
+    feed = mbta_gtfs.get_feed_for_date(service_date)
+    feed.download_or_build()
+    session = feed.create_sqlite_session()
+
+    gtfs_stops = []
+    for start in range(0, len(trip_ids), MAX_QUERY_DEPTH):
+        gtfs_stops.append(
+            pd.read_sql(
+                session.query(
+                    StopTime.trip_id, StopTime.stop_id, StopTime.arrival_time, Trip.route_id, Trip.direction_id
+                )
+                .filter(or_(StopTime.trip_id == tid for tid in trip_ids[start : start + MAX_QUERY_DEPTH]))  # noqa: E203
+                .join(Trip, Trip.trip_id == StopTime.trip_id)
+                .statement,
+                session.bind,
+                dtype_backend="numpy_nullable",
+                dtype={"direction_id": "int16"},
+            )
+        )
+    return pd.concat(gtfs_stops)

--- a/mbta-performance/chalicelib/historic/backfill/main.py
+++ b/mbta-performance/chalicelib/historic/backfill/main.py
@@ -1,10 +1,9 @@
-import threading
 from ..constants import ARCGIS_IDS
 from ..download import download_historic_data, list_files_in_dir, prep_local_dir, unzip_historic_data
 from ..process import process_events
 
 
-def single_year_thread(year: str):
+def backfill_single_year(year: str):
     print(f"Backfilling year {year}")
     # download the data
     zip_file = download_historic_data(year)
@@ -21,18 +20,8 @@ def backfill_all_years():
 
     prep_local_dir()
 
-    year_threads: list[threading.Thread] = []
     for year in ARCGIS_IDS.keys():
-        year_thread = threading.Thread(
-            target=single_year_thread,
-            args=(year,),
-            name=year,
-        )
-        year_threads.append(year_thread)
-        year_thread.start()
-
-    for year_thread in year_threads:
-        year_thread.join()
+        backfill_single_year(year)
 
 
 if __name__ == "__main__":

--- a/mbta-performance/chalicelib/historic/backfill/main.py
+++ b/mbta-performance/chalicelib/historic/backfill/main.py
@@ -20,7 +20,7 @@ def backfill_all_years():
 
     prep_local_dir()
 
-    for year in ARCGIS_IDS.keys():
+    for year in reversed(ARCGIS_IDS.keys()):
         backfill_single_year(year)
 
 

--- a/mbta-performance/chalicelib/historic/gtfs_archive.py
+++ b/mbta-performance/chalicelib/historic/gtfs_archive.py
@@ -1,0 +1,171 @@
+import datetime
+import pandas as pd
+import pathlib
+import shutil
+import urllib.request
+
+from ..date import to_dateint
+
+MAIN_DIR = pathlib.Path("./data/gtfs_archives/")
+MAIN_DIR.mkdir(parents=True, exist_ok=True)
+
+ARCHIVES = pd.read_csv("https://cdn.mbta.com/archive/archived_feeds.txt")
+
+
+def get_gtfs_archive(dateint: int):
+    """
+    Determine which GTFS archive corresponds to the date.
+    Returns that archive folder, downloading if it doesn't yet exist.
+    """
+    matches = ARCHIVES[(ARCHIVES.feed_start_date <= dateint) & (ARCHIVES.feed_end_date >= dateint)]
+    archive_url = matches.iloc[0].archive_url
+
+    archive_name = pathlib.Path(archive_url).stem
+
+    if (MAIN_DIR / archive_name).exists():
+        print(f"Archive for {dateint} already exists: {archive_name}")
+        return MAIN_DIR / archive_name
+
+    # else we have to download it
+    print(f"Downloading archive for {dateint}: {archive_url}")
+    zipfile, _ = urllib.request.urlretrieve(archive_url)
+    shutil.unpack_archive(zipfile, extract_dir=(MAIN_DIR / archive_name), format="zip")
+    # remove temporary zipfile
+    urllib.request.urlcleanup()
+
+    return MAIN_DIR / archive_name
+
+
+def get_services(date: datetime.date, archive_dir: pathlib.Path):
+    """
+    Read calendar.txt to determine which services ran on the given date.
+    Also, incorporate exceptions from calendar_dates.txt for holidays, etc.
+    """
+    dateint = to_dateint(date)
+    day_of_week = date.strftime("%A").lower()
+
+    cal = pd.read_csv(archive_dir / "calendar.txt")
+    current_services = cal[(cal.start_date <= dateint) & (cal.end_date >= dateint)]
+    services = current_services[current_services[day_of_week] == 1].service_id.tolist()
+
+    exceptions = pd.read_csv(archive_dir / "calendar_dates.txt")
+    exceptions = exceptions[exceptions.date == dateint]
+    additions = exceptions[exceptions.exception_type == 1].service_id.tolist()
+    subtractions = exceptions[exceptions.exception_type == 2].service_id.tolist()
+
+    services = (set(services) - set(subtractions)) | set(additions)
+    return list(services)
+
+
+def read_gtfs(date: datetime.date):
+    """
+    Given a date, this function will:
+    - Find the appropriate gtfs archive (downloading if necessary)
+    - Determine which services ran on that date
+    - Return two dataframes containing just the trips and stop_times that ran on that date
+    """
+    dateint = to_dateint(date)
+
+    archive_dir = get_gtfs_archive(dateint)
+    services = get_services(date, archive_dir)
+
+    # specify dtypes to avoid warnings
+    trips = pd.read_csv(
+        archive_dir / "trips.txt",
+        dtype={
+            "route_id": str,
+            "service_id": str,
+            "trip_id": str,
+            "trip_headsign": str,
+            "trip_short_name": str,
+            "block_id": str,
+        },
+    )
+    trips = trips[trips.service_id.isin(services)]
+
+    stops = pd.read_csv(
+        archive_dir / "stop_times.txt",
+        dtype={"trip_id": str, "stop_id": str, "stop_headsign": str, "checkpoint_id": str},
+    )
+    stops = stops[stops.trip_id.isin(trips.trip_id)]
+    stops.arrival_time = pd.to_timedelta(stops.arrival_time)
+    stops.departure_time = pd.to_timedelta(stops.departure_time)
+
+    return trips, stops
+
+
+def add_gtfs_headways(events_df: pd.DataFrame):
+    """
+    This will calculate scheduled headway and traveltime information
+    from gtfs for the routes we care about, and then match our actual
+    events to the scheduled values. This matching is done based on
+    time-of-day, so is not an excact match. Luckily, pandas helps us out
+    with merge_asof.
+    https://pandas.pydata.org/docs/reference/api/pandas.merge_asof.html
+    """
+
+    # defining these columns in particular becasue we use them everywhere
+    RTE_DIR_STOP = ["route_id", "direction_id", "stop_id"]
+
+    results = []
+
+    # wa have to do this day-by-day because gtfs changes so often
+    for service_date, days_events in events_df.groupby("service_date"):
+        all_trips, all_stops = read_gtfs(service_date.date())
+
+        # filter out the trips of interest
+        relevant_trips = all_trips[all_trips.route_id.isin(days_events.route_id)]
+
+        # take only the stops from those trips (adding route and dir info)
+        trip_info = relevant_trips[["trip_id", "route_id", "direction_id"]]
+        gtfs_stops = all_stops.merge(trip_info, on="trip_id", how="right")
+
+        # calculate gtfs headways
+        gtfs_stops = gtfs_stops.sort_values(by="arrival_time")
+        headways = gtfs_stops.groupby(RTE_DIR_STOP).arrival_time.diff()
+        gtfs_stops["scheduled_headway"] = headways.dt.seconds
+
+        # calculate gtfs traveltimes
+        trip_start_times = gtfs_stops.groupby("trip_id").arrival_time.transform("min")
+        gtfs_stops["scheduled_tt"] = (gtfs_stops.arrival_time - trip_start_times).dt.seconds
+
+        # assign each actual timepoint a scheduled headway
+        # merge_asof 'backward' matches the previous scheduled value of 'arrival_time'
+        days_events["arrival_time"] = days_events.event_time - service_date
+        final = pd.merge_asof(
+            days_events.sort_values(by="arrival_time"),
+            gtfs_stops[RTE_DIR_STOP + ["arrival_time", "scheduled_headway"]],
+            on="arrival_time",
+            direction="backward",
+            by=RTE_DIR_STOP,
+        )
+
+        # assign each actual trip a scheduled trip_id, based on when it started the route
+        route_starts = days_events.loc[days_events.groupby("trip_id").event_time.idxmin()]
+        route_starts = route_starts[RTE_DIR_STOP + ["trip_id", "arrival_time"]]
+
+        trip_id_map = pd.merge_asof(
+            route_starts.sort_values(by="arrival_time"),
+            gtfs_stops[RTE_DIR_STOP + ["arrival_time", "trip_id"]],
+            on="arrival_time",
+            direction="nearest",
+            by=RTE_DIR_STOP,
+            suffixes=["", "_scheduled"],
+        )
+        trip_id_map = trip_id_map.set_index("trip_id").trip_id_scheduled
+
+        # use the scheduled trip matching to get the scheduled traveltime
+        final["scheduled_trip_id"] = final.trip_id.map(trip_id_map)
+        final = pd.merge(
+            final,
+            gtfs_stops[RTE_DIR_STOP + ["trip_id", "scheduled_tt"]],
+            how="left",
+            left_on=RTE_DIR_STOP + ["scheduled_trip_id"],
+            right_on=RTE_DIR_STOP + ["trip_id"],
+            suffixes=["", "_gtfs"],
+        )
+
+        # finally, put all the days together
+        results.append(final)
+
+    return pd.concat(results)

--- a/mbta-performance/chalicelib/historic/process.py
+++ b/mbta-performance/chalicelib/historic/process.py
@@ -22,7 +22,11 @@ def process_events(input_csv: str, outdir: str, nozip: bool = False):
     df["event_time"] = df["service_date"] + pd.to_timedelta(df["event_time_sec"], unit="s")
     df.drop(columns=["event_time_sec"], inplace=True)
 
-    df = add_gtfs_headways(df)
+    try:
+        df = add_gtfs_headways(df)
+    except IndexError:
+        # failure to add gtfs benchmarks
+        pass
 
     service_date_month = pd.Grouper(key="service_date", freq="1M")
     grouped = df.groupby([service_date_month, "stop_id"])

--- a/mbta-performance/chalicelib/historic/process.py
+++ b/mbta-performance/chalicelib/historic/process.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pathlib
 from .constants import HISTORIC_COLUMNS
+from .gtfs_archive import add_gtfs_headways
 
 
 def process_events(input_csv: str, outdir: str, nozip: bool = False):
@@ -20,6 +21,8 @@ def process_events(input_csv: str, outdir: str, nozip: bool = False):
 
     df["event_time"] = df["service_date"] + pd.to_timedelta(df["event_time_sec"], unit="s")
     df.drop(columns=["event_time_sec"], inplace=True)
+
+    df = add_gtfs_headways(df)
 
     service_date_month = pd.Grouper(key="service_date", freq="1M")
     grouped = df.groupby([service_date_month, "stop_id"])

--- a/mbta-performance/chalicelib/lamp/backfill/main.py
+++ b/mbta-performance/chalicelib/lamp/backfill/main.py
@@ -1,17 +1,19 @@
 import pandas as pd
 from ..ingest import fetch_pq_file_from_remote, ingest_pq_file, upload_to_s3
 from ... import parallel
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 
 
 _parallel_upload = parallel.make_parallel(upload_to_s3)
+
+EARLIEST_LAMP_DATA = date(2019, 9, 15)
 
 
 def backfill_all_in_index():
     """Backfill all the dates in the LAMP index."""
 
     # all dates that LAMP has data for, starting from 2019-09-15
-    dates = pd.date_range(datetime(2019, 9, 15).date(), datetime.today().date() - timedelta(days=1), freq="d")
+    dates = pd.date_range(EARLIEST_LAMP_DATA, date.today() - timedelta(days=1), freq="d")
 
     # Backfill each date, most recent to oldest
     for backfill_timestamp in dates[::-1]:

--- a/mbta-performance/chalicelib/lamp/backfill/main.py
+++ b/mbta-performance/chalicelib/lamp/backfill/main.py
@@ -14,13 +14,14 @@ def backfill_all_in_index():
     # Get the dates in the index
     dates = pd.to_datetime(index["service_date"]).dt.date
     # Backfill each date
-    for date_to_backfill in dates:
+    for date_to_backfill in dates.reindex(index=dates.index[::-1]):
         try:
             pq_df = fetch_pq_file_from_remote(date_to_backfill)
         except ValueError as e:
             # If we can't fetch the file, we can't process it
             print(f"Failed to fetch {date_to_backfill}: {e}")
-        processed_daily_events = ingest_pq_file(pq_df)
+        print(f"Processing {date_to_backfill}")
+        processed_daily_events = ingest_pq_file(pq_df, date_to_backfill)
 
         # split daily events by stop_id and parallel upload to s3
         stop_event_groups = processed_daily_events.groupby("stop_id")

--- a/mbta-performance/chalicelib/lamp/ingest.py
+++ b/mbta-performance/chalicelib/lamp/ingest.py
@@ -174,6 +174,7 @@ def _average_scheduled_headways(pq_df: pd.DataFrame, service_date: date) -> pd.D
 
     We do this so as to smooth the benchmark headways for the data dashboard.
     TODO: do this with branch headways as well
+    TODO: group green line branches together in trunk headways
     """
     # service date starts at 5:30am, but there are enough very early/late departures that we dont want to be opinionated
     start_time = pd.Timestamp(service_date.year, service_date.month, service_date.day)

--- a/mbta-performance/chalicelib/lamp/ingest.py
+++ b/mbta-performance/chalicelib/lamp/ingest.py
@@ -182,7 +182,7 @@ def _average_scheduled_headways(pq_df: pd.DataFrame, service_date: date) -> pd.D
     for bucket in buckets:
         bucket_start = pd.to_datetime(bucket, unit="s").tz_localize("US/Eastern")
         bucket_end = pd.to_datetime(bucket + pd.Timedelta(minutes=30), unit="s").tz_localize("US/Eastern")
-        filtered_trips = pq_df[(pq_df["dep_time"] >= bucket_start) & (pq_df["dep_time"] < bucket_end)]
+        filtered_trips = pq_df[(pq_df["event_time"] >= bucket_start) & (pq_df["event_time"] < bucket_end)]
         filtered_trips = filtered_trips[filtered_trips["scheduled_headway"].notna()]
 
         # Get the average headway per route
@@ -208,7 +208,7 @@ def ingest_pq_file(pq_df: pd.DataFrame, service_date: date) -> pd.DataFrame:
     processed_daily_events = _process_arrival_departure_times(pq_df)
     processed_daily_events = processed_daily_events[processed_daily_events["stop_id"].notna()]
     processed_daily_events = _recalculate_fields_from_gtfs(processed_daily_events, service_date)
-    processed_daily_events = _average_scheduled_headways(processed_daily_events, service_date)
+    # processed_daily_events = _average_scheduled_headways(processed_daily_events, service_date)
 
     return processed_daily_events.sort_values(by=["event_time"])
 


### PR DESCRIPTION
Starts #20 

Fixed #22 

Smooths the scheduled headway benchmarks along route/dir/stop.

Red line headways before...
<img width="470" alt="Headways" src="https://github.com/transitmatters/mbta-performance/assets/69647229/c5c3b5cc-2687-4729-9a8d-a53589c0ce19">


and after (: 
<img width="565" alt="Headways" src="https://github.com/transitmatters/mbta-performance/assets/69647229/9f959a45-30ce-415d-9834-99294e05da7d">