### PR TITLE
Upload feed to s3 when not present

### DIFF
--- a/mbta-performance/chalicelib/gtfs.py
+++ b/mbta-performance/chalicelib/gtfs.py
@@ -21,7 +21,7 @@ def fetch_stop_times_from_gtfs(trip_ids: Iterable[str], service_date: date) -> p
     )
     feed = mbta_gtfs.get_feed_for_date(service_date)
     feed.download_or_build()
-    session = feed.create_sqlite_session(compact=True)
+    session = feed.create_sqlite_session()
     exists_remotely = feed.exists_remotely()
 
     gtfs_stops = []

--- a/mbta-performance/chalicelib/gtfs.py
+++ b/mbta-performance/chalicelib/gtfs.py
@@ -21,7 +21,7 @@ def fetch_stop_times_from_gtfs(trip_ids: Iterable[str], service_date: date) -> p
     )
     feed = mbta_gtfs.get_feed_for_date(service_date)
     feed.download_or_build()
-    session = feed.create_sqlite_session()
+    session = feed.create_sqlite_session(compact=True)
     exists_remotely = feed.exists_remotely()
 
     gtfs_stops = []


### PR DESCRIPTION
Occasionally GTFS feeds get uploaded mid-day and then the lambda needs to download and build the feed. If that happens, we should upload it to s3 after so that the next run is quick and error free