### PR TITLE
Shift process timing for LAMP

### DIFF
--- a/mbta-performance/app.py
+++ b/mbta-performance/app.py
@@ -9,7 +9,7 @@ app = Chalice(app_name="mbta-performance")
 app.register_middleware(ConvertToMiddleware(datadog_lambda_wrapper))
 
 
-# Runs every 30 minutes from either 4 AM -> 1:55AM or 5 AM -> 2:55 AM depending on DST
-@app.schedule(Cron("*/30", "0-6,9-23", "*", "*", "?", "*"))
+# Runs every 30 minutes from either 5 AM -> 2:30AM or 6 AM -> 3:30 AM depending on DST
+@app.schedule(Cron("*/30", "0-7,10-23", "*", "*", "?", "*"))
 def process_daily_lamp(event):
     lamp.ingest_today_lamp_data()


### PR DESCRIPTION
We're starting to process too early in the morning, before a LAMP file is even ready, and were not processing late enough at night to get the full day of data on weekends.

This shifts the timing back an hour to account for this