### PR TITLE
Ensure we don't run before 6am, and process full days

### DIFF
--- a/mbta-performance/.chalice/config.json
+++ b/mbta-performance/.chalice/config.json
@@ -22,6 +22,11 @@
           "iam_policy_file": "policy-lamp-ingest.json",
           "lambda_timeout": 900,
           "lambda_memory_size": 2048
+        },
+        "process_yesterday_lamp": {
+          "iam_policy_file": "policy-lamp-ingest.json",
+          "lambda_timeout": 900,
+          "lambda_memory_size": 2048
         }
       }
     }

--- a/mbta-performance/.chalice/resources.json
+++ b/mbta-performance/.chalice/resources.json
@@ -35,6 +35,28 @@
           "Size": 2048
         }
       }
+    },
+    "ProcessYesterdayLamp": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Environment": {
+          "Variables": {
+            "DD_LAMBDA_HANDLER": "app.process_yesterday_lamp",
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 2048
+        }
+      }
     }
   }
 }

--- a/mbta-performance/app.py
+++ b/mbta-performance/app.py
@@ -24,8 +24,8 @@ def process_daily_lamp(event):
     lamp.ingest_today_lamp_data()
 
 
-# Runs once the next day at 9am or 10am depending on DST
-@app.schedule(Cron("0", "13", "*", "*", "?", "*"))
+# Runs once the next day at 11am or 12pm depending on DST
+@app.schedule(Cron("0", "15", "*", "*", "?", "*"))
 def process_yesterday_lamp(event):
     """Process yesterday's LAMP data, to ensure we have everything we need."""
     lamp.ingest_yesterday_lamp_data()

--- a/mbta-performance/app.py
+++ b/mbta-performance/app.py
@@ -15,7 +15,7 @@ app.register_middleware(ConvertToMiddleware(datadog_lambda_wrapper))
 @app.schedule(Cron("*/30", "0-7,10-23", "*", "*", "?", "*"))
 def process_daily_lamp(event):
     """Ensure execution only happens at 6 AM or later in Boston time."""
-    now_boston = datetime.now(ZoneInfo("America/New_York"))
+    now_boston = datetime.now(ZoneInfo("US/Eastern"))
 
     # If it's before 6 AM Boston time, exit early to avoid errors
     if now_boston.hour >= 3 and now_boston.hour < 6:

--- a/mbta-performance/app.py
+++ b/mbta-performance/app.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from chalice import Chalice, Cron, ConvertToMiddleware
 from datadog_lambda.wrapper import datadog_lambda_wrapper
 from chalicelib import (
@@ -12,4 +14,18 @@ app.register_middleware(ConvertToMiddleware(datadog_lambda_wrapper))
 # Runs every 30 minutes from either 5 AM -> 2:30AM or 6 AM -> 3:30 AM depending on DST
 @app.schedule(Cron("*/30", "0-7,10-23", "*", "*", "?", "*"))
 def process_daily_lamp(event):
+    """Ensure execution only happens at 6 AM or later in Boston time."""
+    now_boston = datetime.now(ZoneInfo("America/New_York"))
+
+    # If it's before 6 AM Boston time, exit early to avoid errors
+    if now_boston.hour >= 3 and now_boston.hour < 6:
+        return
+
     lamp.ingest_today_lamp_data()
+
+
+# Runs once the next day at 9am or 10am depending on DST
+@app.schedule(Cron("0", "13", "*", "*", "?", "*"))
+def process_yesterday_lamp(event):
+    """Process yesterday's LAMP data, to ensure we have everything we need."""
+    lamp.ingest_yesterday_lamp_data()

--- a/mbta-performance/chalicelib/lamp/ingest.py
+++ b/mbta-performance/chalicelib/lamp/ingest.py
@@ -241,9 +241,7 @@ def upload_to_s3(stop_id_and_events: Tuple[str, pd.DataFrame], service_date: dat
 _parallel_upload = parallel.make_parallel(upload_to_s3)
 
 
-def ingest_today_lamp_data():
-    """Ingest and upload today's LAMP data."""
-    service_date = get_current_service_date()
+def ingest_lamp_data(service_date: date):
     try:
         pq_df = fetch_pq_file_from_remote(service_date)
     except ValueError as e:
@@ -255,6 +253,18 @@ def ingest_today_lamp_data():
     # split daily events by stop_id and parallel upload to s3
     stop_event_groups = processed_daily_events.groupby("stop_id")
     _parallel_upload(stop_event_groups, service_date)
+
+
+def ingest_today_lamp_data():
+    """Ingest and upload today's LAMP data."""
+    service_date = get_current_service_date()
+    ingest_lamp_data(service_date)
+
+
+def ingest_yesterday_lamp_data():
+    """Ingest and upload yesterday's LAMP data."""
+    service_date = get_current_service_date() - pd.Timedelta(days=1)
+    ingest_lamp_data(service_date)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We currently try running at 5am, before data is uploaded. We don't need to do that. First process should start at 6am

We also should make sure that if the T does any cleanup on the previous day, we catch it and process it the day after

This should result in slightly less runs overall, while ensuring data quality