### PR TITLE
Added support for Ferry Data Processing

### DIFF
--- a/mbta-performance/chalicelib/historic/README.md
+++ b/mbta-performance/chalicelib/historic/README.md
@@ -2,6 +2,13 @@
 
 MBTA uploads monthly data files periodically. These monthly batches take the place of performance data when available (This may change with LAMP).
 
+## Backfill Ferry Data
+MBTA updates the Ferry data ~every 6 months or so. 
+
+```sh
+poetry run python -m mbta-performance.chalicelib.historic.backfill.ferry
+```
+
 ## Backfill all years
 
 This should only be done if we change the processing code or need to repopulate an empty bucket

--- a/mbta-performance/chalicelib/historic/arcgis.py
+++ b/mbta-performance/chalicelib/historic/arcgis.py
@@ -1,0 +1,22 @@
+from tempfile import NamedTemporaryFile
+import requests
+
+from .constants import FERRY_UPDATE_CACHE_URL, FERRY_RIDERSHIP_ARCGIS_URL
+
+
+def ferry_update_cache():
+    """
+    This function is used to update the cache for the Ferry ridership data
+    on the ArcGIS Hub. This is necessary because the data is large enough
+    where the cache isn't updated automatically.
+    """
+    requests.get(FERRY_UPDATE_CACHE_URL)
+
+
+def download_latest_ferry_data() -> str:
+    ferry_tmp_path = NamedTemporaryFile().name
+
+    with open(ferry_tmp_path, "wb") as file:
+        req = requests.get(FERRY_RIDERSHIP_ARCGIS_URL, timeout=15)
+        file.write(req.content)
+    return ferry_tmp_path

--- a/mbta-performance/chalicelib/historic/backfill/ferry.py
+++ b/mbta-performance/chalicelib/historic/backfill/ferry.py
@@ -1,0 +1,16 @@
+from ..process import process_ferry
+from ..arcgis import download_latest_ferry_data, ferry_update_cache
+
+
+def backfill_ferry_data():
+    print("Processing Ferry Data")
+    ferry_update_cache()
+    # download the data
+    csv_file = download_latest_ferry_data()
+
+    process_ferry(csv_file, "data/output")
+    print("Finished Processing Ferry Data")
+
+
+if __name__ == "__main__":
+    backfill_ferry_data()

--- a/mbta-performance/chalicelib/historic/constants.py
+++ b/mbta-performance/chalicelib/historic/constants.py
@@ -37,3 +37,102 @@ HISTORIC_COLUMNS_LAMP = [
     "event_type",
     "event_time_sec",
 ]
+
+
+#  Ferry Section
+FERRY_UPDATE_CACHE_URL = "https://hub.arcgis.com/api/download/v1/items/ae21643bbe60488db8520cc694f882aa/csv?redirect=false&layers=0&updateCache=true"
+FERRY_RIDERSHIP_ARCGIS_URL = "https://hub.arcgis.com/api/v3/datasets/ae21643bbe60488db8520cc694f882aa_0/downloads/data?format=csv&spatialRefId=4326&where=1%3D1"
+
+
+CSV_FIELDS = [
+    "service_date",
+    "route_id",
+    "trip_id",
+    "direction_id",
+    "stop_id",
+    "stop_sequence",
+    "vehicle_id",
+    "vehicle_label",
+    "event_type",
+    "event_time",
+    "scheduled_headway",
+    "scheduled_tt",
+    "vehicle_consist",
+]
+
+
+unofficial_ferry_labels_map = {
+    "F1": "Boat-F1",
+    "F2H": "Boat-F1",
+    "F3": "Boat-EastBoston",
+    "F4": "Boat-F4",
+    "F5": "Boat-Lynn",
+    "F6": "Boat-F6",
+    "F7": "Boat-F7",
+    "F8": "Boat-F8",
+}
+
+inbound_outbound = {"From Boston": 0, "To Boston": 1}
+
+example_field_mapping = {
+    "service_date": "service_date",
+    "route_id": "route_id",
+    "trip_id": "trip_id",
+    "direction_id": "travel_direction",
+    "stop_id": "stop_id",
+    "stop_sequence": None,
+    "vehicle_id": "vessel_time_slot",
+    "vehicle_label": None,
+    "event_type": None,
+    "event_time": "actual_arrival",
+    "scheduled_headway": "mbta_sched_arrival",
+    "scheduled_tt": None,
+    "vehicle_consist": None,
+}
+
+arrival_field_mapping = {
+    "service_date": "service_date",
+    "route_id": "route_id",
+    "trip_id": "trip_id",
+    "travel_direction": "direction_id",
+    "arrival_terminal": "stop_id",
+    "vessel_time_slot": "vehicle_id",
+    "actual_arrival": "event_time",
+    "mbta_sched_arrival": "scheduled_headway",
+    "scheduled_tt": "scheduled_tt",
+}
+
+departure_field_mapping = {
+    "service_date": "service_date",
+    "route_id": "route_id",
+    "trip_id": "trip_id",
+    "travel_direction": "direction_id",
+    "departure_terminal": "stop_id",
+    "vessel_time_slot": "vehicle_id",
+    "actual_departure": "event_time",
+    "mbta_sched_departure": "scheduled_headway",
+    "scheduled_tt": "scheduled_tt",
+}
+
+# For these I used context clues from the CSV and then matched up using the MBTA Website to find Stop IDs
+station_mapping = {
+    "Aquarium": "Boat-Aquarium",
+    "Boston": "Boat-Long",
+    "Central Whf": "Boat-Aquarium",
+    "Georges": "Boat-George",
+    "Hingham": "Boat-Hingham",
+    "Hull": "Boat-Hull",
+    "Lewis": "Boat-Lewis",
+    "Logan": "Boat-Logan",
+    "Long Wharf N": "Boat-Long",
+    "Long Wharf S": "Boat-Long-South",
+    "Lynn": "Boat-Blossom",
+    "Navy Yard": "Boat-Charlestown",
+    "Quincy": "Boat-Quincy",
+    "Rowes": "Boat-Rowes",
+    "Rowes Wharf": "Boat-Rowes",
+    "Seaport": "Boat-Fan",
+    "Winthrop": "Boat-Winthrop",
+    "HULL": "Boat-Hull",
+    "LOGAN": "Boat-Logan",
+}

--- a/mbta-performance/chalicelib/historic/process.py
+++ b/mbta-performance/chalicelib/historic/process.py
@@ -1,7 +1,16 @@
 import pandas as pd
 import pathlib
 from .constants import HISTORIC_COLUMNS_PRE_LAMP as HISTORIC_COLUMNS
+from .constants import (
+    CSV_FIELDS,
+    arrival_field_mapping,
+    departure_field_mapping,
+    station_mapping,
+    unofficial_ferry_labels_map,
+    inbound_outbound,
+)
 from .gtfs_archive import add_gtfs_headways
+from ..date import service_date as get_service_date
 
 
 def process_events(input_csv: str, outdir: str, nozip: bool = False, columns: list = HISTORIC_COLUMNS):
@@ -57,3 +66,65 @@ def to_disk(df: pd.DataFrame, outdir, nozip=False):
         fname.parent.mkdir(parents=True, exist_ok=True)
         # set mtime to 0 in gzip header for determinism (so we can re-gen old routes, and rsync to s3 will ignore)
         events.to_csv(fname, index=False, compression={"method": "gzip", "mtime": 0} if not nozip else None)
+
+
+def process_ferry(
+    path_to_csv_file: str,
+    outdir: str,
+    nozip: bool = False,
+):
+    # read data, convert to datetime
+    df = pd.read_csv(path_to_csv_file, low_memory=False)
+
+    # Calculate Travel time in Minutes
+    time_diff = pd.to_datetime(df["mbta_sched_arrival"]) - pd.to_datetime(df["mbta_sched_departure"])
+    df["scheduled_tt"] = time_diff.dt.total_seconds() / 60
+
+    # Convert To Boston/From Boston to Inbound/Outbound Values
+    df["travel_direction"] = df["travel_direction"].replace(inbound_outbound).infer_objects(copy=False)
+    # Convert direction_id to integer to ensure outputs are integers
+    df["travel_direction"] = df["travel_direction"].astype("Int64")
+    # Replace terminal values with GTFS Approved Values
+    df["departure_terminal"] = df["departure_terminal"].replace(station_mapping)
+    df["arrival_terminal"] = df["arrival_terminal"].replace(station_mapping)
+    # Replace Route_ids based on mapping
+    df["route_id"] = df["route_id"].replace(unofficial_ferry_labels_map)
+
+    # Subset dataframe to just arrival and departure event data - create copies to avoid warnings
+    arrival_events = df[arrival_field_mapping.keys()].copy()
+    departure_events = df[departure_field_mapping.keys()].copy()
+
+    arrival_events.rename(columns=arrival_field_mapping, inplace=True)
+    departure_events.rename(columns=departure_field_mapping, inplace=True)
+
+    # Add missing columns with default values
+    for events_df in [arrival_events, departure_events]:
+        events_df["stop_sequence"] = None
+        events_df["vehicle_label"] = None
+        events_df["vehicle_consist"] = None
+
+    # Add event_type to distinguish between arrivals and departures
+    arrival_events.loc[:, "event_type"] = "ARR"
+    departure_events.loc[:, "event_type"] = "DEP"
+
+    # Convert event_time to datetime, handling mixed formats
+    arrival_events.loc[:, "event_time"] = pd.to_datetime(arrival_events["event_time"], format="mixed", errors="coerce")
+    departure_events.loc[:, "event_time"] = pd.to_datetime(
+        departure_events["event_time"], format="mixed", errors="coerce"
+    )
+
+    arrival_events = arrival_events[CSV_FIELDS]
+    departure_events = departure_events[CSV_FIELDS]
+    df = pd.concat([arrival_events, departure_events])
+
+    # Convert service_date to datetime for proper grouping in to_disk()
+    # First convert to datetime, then apply service_date logic, then back to datetime
+    df.loc[:, "service_date"] = pd.to_datetime(df["service_date"], errors="coerce").apply(
+        lambda x: pd.to_datetime(get_service_date(x)) if pd.notna(x) else x
+    )
+
+    # Load route constants and add stop sequence information
+    # route_dicts = load_constants()
+    # events = add_stop_sequence_to_dataframe(events, route_dicts)
+
+    to_disk(df, outdir, nozip)


### PR DESCRIPTION
Moved over processing from [data-ingestion PR 139](https://github.com/transitmatters/data-ingestion/pull/139)

If we get the [t-performance-dash PR 1078](https://github.com/transitmatters/t-performance-dash/pull/1078) into beta it would be great if we could pair it with uploading this initial data processing to confirm everything looks as it should. 

To test use: 
```sh
poetry run python -m mbta-performance.chalicelib.historic.backfill.ferry
```