### PR TITLE
Ferry data cleaning

### DIFF
--- a/mbta-performance/chalicelib/historic/process.py
+++ b/mbta-performance/chalicelib/historic/process.py
@@ -85,6 +85,8 @@ def process_ferry(
     df["mbta_sched_departure"] = pd.to_datetime(df["mbta_sched_departure"], errors="coerce").dt.tz_convert(
         tz="US/Eastern"
     )
+    df["actual_departure"] = pd.to_datetime(df["actual_departure"], errors="coerce").dt.tz_convert(tz="US/Eastern")
+    df["actual_arrival"] = pd.to_datetime(df["actual_arrival"], errors="coerce").dt.tz_convert(tz="US/Eastern")
 
     # Calculate Travel time in Minutes - only for rows that have both arrival and departure times
     # This should be calculated per trip, not per event

--- a/mbta-performance/chalicelib/historic/process.py
+++ b/mbta-performance/chalicelib/historic/process.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import uuid
 import pathlib
 from .constants import HISTORIC_COLUMNS_PRE_LAMP as HISTORIC_COLUMNS
 from .constants import (
@@ -81,7 +82,6 @@ def process_ferry(
     df.dropna(
         subset=[
             "travel_direction",
-            "trip_id",
             "departure_terminal",
             "mbta_sched_arrival",
             "mbta_sched_departure",
@@ -89,6 +89,9 @@ def process_ferry(
             "actual_arrival",
         ]
     )
+
+    missing_trip_ids_mask = df["trip_id"].isna()
+    df.loc[missing_trip_ids_mask, "trip_id"] = [str(uuid.uuid4()) for _ in range(missing_trip_ids_mask.sum())]
 
     # Convert to datetime first, then apply timezone localization
     df["mbta_sched_arrival"] = pd.to_datetime(df["mbta_sched_arrival"], errors="coerce").dt.tz_convert(tz="US/Eastern")

--- a/mbta-performance/chalicelib/historic/process.py
+++ b/mbta-performance/chalicelib/historic/process.py
@@ -73,7 +73,7 @@ def to_disk(df: pd.DataFrame, outdir, nozip=False):
 def process_ferry(
     path_to_csv_file: str,
     outdir: str,
-    nozip: bool = True,
+    nozip: bool = False,
 ):
     # read data, convert to datetime
     df = pd.read_csv(path_to_csv_file, low_memory=False)


### PR DESCRIPTION
This dataset needed more cleaning than initially assumed. I added logic to filter out the rows with too much missing information. 

I also made sure that all datetimes were in Eastern Time. And also found an issue where some travel times would be negative. This is because some of the scheduled departure times would be a day later. So, for any row with a negative travel time, I set the scheduled_departure_time to be a day before and re-process. This should hopefully clean up some of the issues we're seeing. 

| trip_id          | mbta_sched_departure   | actual_departure | mbta_sched_arrival     | actual_arrival |
| ---------------- | ---------------------- | ---------------- | ---------------------- | -------------- |
| 19:30-F1-RWF-HNG | 2025/01/03 00:30:00+00 | 1/2/2025 19:30   | 2025/01/02 05:00:00+00 | 1/2/2025 20:01 |