### PR TITLE
cleaned up ferry processing

### DIFF
--- a/mbta-performance/chalicelib/historic/constants.py
+++ b/mbta-performance/chalicelib/historic/constants.py
@@ -68,8 +68,6 @@ CSV_FIELDS = [
     "vehicle_label",
     "event_type",
     "event_time",
-    "scheduled_headway",
-    "scheduled_tt",
     "vehicle_consist",
 ]
 
@@ -110,7 +108,6 @@ arrival_field_mapping = {
     "arrival_terminal": "stop_id",
     "vessel_time_slot": "vehicle_id",
     "actual_arrival": "event_time",
-    "scheduled_tt": "scheduled_tt",
 }
 
 departure_field_mapping = {
@@ -121,7 +118,6 @@ departure_field_mapping = {
     "departure_terminal": "stop_id",
     "vessel_time_slot": "vehicle_id",
     "actual_departure": "event_time",
-    "scheduled_tt": "scheduled_tt",
 }
 
 # For these I used context clues from the CSV and then matched up using the MBTA Website to find Stop IDs


### PR DESCRIPTION
I wanted to diagnose why the schedule_tt was returning null in the frontend API. After digging through some data processing, I found that the add_gtfs_headways adds both the scheduled_headway and scheduled_tt fields. 

I removed these fields from prior field mapping so that the input dataframe does not have any conflicting field names which may cause _x and _y duplicate fields, or worse that the field is not calculated at all. 

Here is an example of how the data looks now: 

<img width="959" height="452" alt="image" src="https://github.com/user-attachments/assets/a8b33b15-2c84-470d-b984-8aa275fb0a59" />
