### PR TITLE
Try doubling memory to prevent OOM

### DIFF
--- a/mbta-performance/.chalice/config.json
+++ b/mbta-performance/.chalice/config.json
@@ -26,7 +26,7 @@
         "process_yesterday_lamp": {
           "iam_policy_file": "policy-lamp-ingest.json",
           "lambda_timeout": 900,
-          "lambda_memory_size": 2048
+          "lambda_memory_size": 4096
         }
       }
     }


### PR DESCRIPTION
The last process daily LAMP has been hitting OOM. This doubles the memory for the lambda to get a better idea of how much memory the process actually needs. 

REPORT RequestId: 0d7d0d92-e484-4090-93f7-87a1c6d9bbde Duration: 89686.41 ms Billed Duration: 89687 ms Memory Size: 2048 MB Max Memory Used: 2048 MB Status: error Error Type: Runtime.OutOfMemory