### PR TITLE
increase daily lamp mem allocation

### DIFF
--- a/mbta-performance/.chalice/config.json
+++ b/mbta-performance/.chalice/config.json
@@ -21,7 +21,7 @@
         "process_daily_lamp": {
           "iam_policy_file": "policy-lamp-ingest.json",
           "lambda_timeout": 60,
-          "lambda_memory_size": 2048
+          "lambda_memory_size": 4096
         },
         "process_yesterday_lamp": {
           "iam_policy_file": "policy-lamp-ingest.json",


### PR DESCRIPTION
I checked the DataDog Dashboard and it looks like the update GTFS function is currently using ~3gb of memory. 

<img width="744" height="84" alt="image" src="https://github.com/user-attachments/assets/b76dceda-a4bd-4219-a3f2-b4e5fd62bed2" />

Since this seems to be the new baseline, it may be worth bumping the memory allocation. 